### PR TITLE
Fixes #6. Removes nil check, now `join()` always returns empty string.

### DIFF
--- a/csv.nim
+++ b/csv.nim
@@ -52,7 +52,7 @@ proc parseAll*(
             cleanedLines.add(line)
     var cleanedcsv: string = cleanedLines.join("\n")
 
-    if cleanedcsv == nil or cleanedcsv.strip() == "":
+    if cleanedcsv.strip() == "":
         return csvSeq
     
     # Check if the CSV has a blank field on every row:


### PR DESCRIPTION
The nil change for string/seqs happened in Nim version 0.19.0, see
https://nim-lang.org/blog/2018/09/26/version-0190-released.html.